### PR TITLE
Made the docker ip configurable for the integration tests

### DIFF
--- a/src/main/scala/freeslick/OracleProfile.scala
+++ b/src/main/scala/freeslick/OracleProfile.scala
@@ -126,8 +126,9 @@ trait OracleProfile extends JdbcDriver with DriverRowNumberPagination with Frees
         case Library.Database() => b"sys_context('userenv','db_name')"
         // Oracle driver directly supports only getNumericFunctions()
         // "ABS,ACOS,ASIN,ATAN,ATAN2,CEILING,COS,EXP,FLOOR,LOG,LOG10,MOD,PI,POWER,ROUND,SIGN,SIN,SQRT,TAN,TRUNCATE";
-        case Library.Degrees(ch) => b"57.2957795 * $ch"
-        case Library.Radians(ch) => b"0.0174532925 * $ch"
+        case Library.Pi => b"(2*ASIN(1))" // // ASIN(1) is Pi/2. Oracle 11g doesn't have a PI function.
+        case Library.Degrees(ch) => b"(360 * $ch / ASIN(1) / 4)"
+        case Library.Radians(ch) => b"(ASIN(1) * 4 * $ch / 360 )"
         case Library.Repeat(ch, times) => b"ltrim(rpad('x', length($ch)*$times+1, $ch), 'x')"
         case _ => super.expr(n, skipParens)
       }

--- a/test-dbs/testkit.conf
+++ b/test-dbs/testkit.conf
@@ -5,6 +5,25 @@
 # Use only the following DBs (or use all if not set)
 #testDBs = sqlserver
 
+
+# For docker-machine use:
+#   DOCKER_IP=$(docker-machine ip default)
+#   export DOCKER_IP
+
+db2.host = "localhost"
+db2.host = ${?DOCKER_IP}
+db2NoTableSpace.host = "localhost"
+db2NoTableSpace.host = ${?DOCKER_IP}
+oracle11g.host = "localhost"
+oracle11g.host = ${?DOCKER_IP}
+oracle11gNoTableSpace.host = "localhost"
+oracle11gNoTableSpace.host = ${?DOCKER_IP}
+# ATTENTION: I cannot factor out the host in a common variable, because this file is included in a bigger config
+# file. This leads to a prefix put before all the names. Unfortunately HOCON doesn't support relative paths and
+# I don't know the common prefix.
+
+
+
 testkit {
   # Set this high otherwise tests fail when debugging
   asyncTimeout = 50 minutes
@@ -13,7 +32,7 @@ testkit {
 
 db2 {
   enabled = true
-  baseURL = "jdbc:db2://localhost:50000/DSNFREE"
+  baseURL = "jdbc:db2://"${host}":50000/DSNFREE"
   user = db2inst1
   password = db2inst1-pwd
   testDB = ""
@@ -48,7 +67,7 @@ db2 {
 
 db2NoTableSpace {
   enabled = true
-  baseURL = "jdbc:db2://localhost:50000/DSNFREE"
+  baseURL = "jdbc:db2://"${host}":50000/DSNFREE"
   user = db2inst1
   password = db2inst1-pwd
   testDB = ""
@@ -71,7 +90,7 @@ db2NoTableSpace {
 
 sqlserver2008 {
   enabled = true
-  baseURL = "jdbc:jtds:sqlserver://localhost:2008/"
+  baseURL = "jdbc:jtds:sqlserver://"${host}":2008/"
   user = sa
   password = FreeSlick
   testDB = freeslicktest
@@ -91,7 +110,7 @@ sqlserver2008 {
 
 oracle11g {
   enabled = true
-  baseURL = "jdbc:oracle:thin:@//localhost:49161/xe"
+  baseURL = "jdbc:oracle:thin:@//"${host}":49161/xe"
   testDB = ""
   admindb = ""
   adminConn {
@@ -134,7 +153,7 @@ oracle11g {
 
 oracle11gNoTableSpace {
   enabled = true
-  baseURL = "jdbc:oracle:thin:@//localhost:49161/xe"
+  baseURL = "jdbc:oracle:thin:@//"${host}":49161/xe"
   testDB = ""
   admindb = ""
   adminConn {

--- a/test-dbs/testkit.conf
+++ b/test-dbs/testkit.conf
@@ -18,6 +18,8 @@ oracle11g.host = "localhost"
 oracle11g.host = ${?DOCKER_IP}
 oracle11gNoTableSpace.host = "localhost"
 oracle11gNoTableSpace.host = ${?DOCKER_IP}
+sqlserver2008.host = "localhost"
+sqlserver2008.host = ${?DOCKER_IP} # This will probably run on a separate, Windows based Docker host
 # ATTENTION: I cannot factor out the host in a common variable, because this file is included in a bigger config
 # file. This leads to a prefix put before all the names. Unfortunately HOCON doesn't support relative paths and
 # I don't know the common prefix.


### PR DESCRIPTION
- [Feature] You can now set the variable to the Docker host via a config variable for the integration tests
- [Feature] The config variable for the docker host defaults to local host
- [Feature] The config file testkit.conf describes how to set the variable with docker-machine / boot2docker
