### PR TITLE
Don't specify CLOB mapping explicitly. The MappedType takes care of t…

### DIFF
--- a/src/it/scala/freeslick/profile/FreeslickDriverTest.scala
+++ b/src/it/scala/freeslick/profile/FreeslickDriverTest.scala
@@ -19,7 +19,7 @@ class FreeslickDriverTest(driver: TestDB) extends DriverTest(driver) {
       classOf[JDBCFunctionTest] :+
       classOf[UUIDTest]
     //TODO Sue timestamps, blobs, all the jdbcfunctions
-    //Seq(classOf[FreeslickInsertTest])
+    //Seq(classOf[FreeslickClobTest])
   }
 }
 

--- a/src/it/scala/freeslick/testkit/FreeslickClobTest.scala
+++ b/src/it/scala/freeslick/testkit/FreeslickClobTest.scala
@@ -24,7 +24,7 @@ class FreeslickClobTest extends AsyncTest[JdbcTestDB] {
 
   class T(tableName: String)(tag: Tag) extends Table[(Int, LongString)](tag, tableName) {
     def id = column[Int]("ID", O.AutoInc, O.PrimaryKey)
-    def name = column[LongString]("NAME", O.SqlType("CLOB"))
+    def name = column[LongString]("NAME")
     def * = (id, name)
   }
 
@@ -38,7 +38,7 @@ class FreeslickClobTest extends AsyncTest[JdbcTestDB] {
         val data = longCharSeq
         for {
           // Single insert returns single auto inc value
-          _ <- ts +=(0, LongString(data))
+          _ <- ts += (0, LongString(data))
           _ <- ts.sortBy(_.id).result.map{ s =>
             s.length shouldBe 1
             s.head._1 shouldBe 1


### PR DESCRIPTION
…he mapping and Profile override doesn't get chance to work.

This fixes the SQLServer profile break
