### PR TITLE
top requires parens for parameters, e.g. in compiled queries

### DIFF
--- a/src/it/scala/freeslick/testkit/FetchOffsetTest.scala
+++ b/src/it/scala/freeslick/testkit/FetchOffsetTest.scala
@@ -44,6 +44,9 @@ class FetchOffsetTest extends AsyncTest[JdbcTestDB] {
       _ <- q2.drop(7).take(50).map(_.age).result.map(_ shouldBe data.map(_._2).sorted.slice(7,57))
     // taking passed the end should be empty
       _ <- q2.drop(data.size).take(50).map(_.age).result.map(_ shouldBe Seq())
+    // taking with compiled query
+      takeMaxCompiled = Compiled((max: ConstColumn[Long]) => people.take(max))
+      _ <- takeMaxCompiled(3).result.map(_.size shouldBe 3)
     } yield ()
   }
 }

--- a/src/main/scala/freeslick/MSSQLServerProfile.scala
+++ b/src/main/scala/freeslick/MSSQLServerProfile.scala
@@ -108,7 +108,7 @@ trait MSSQLServerProfile extends JdbcDriver with DriverRowNumberPagination { dri
     override protected def buildSelectModifiers(c: Comprehension) {
       (c.fetch, c.offset) match {
         case (Some(t), Some(d)) => b"top ($d + $t) "
-        case (Some(t), None) => b"top $t "
+        case (Some(t), None) => b"top ($t) "
         case (None, _) => if (c.orderBy.nonEmpty) b"top 100 percent "
       }
       super.buildSelectModifiers(c)


### PR DESCRIPTION
This cropped up using `MSJDBCSQLServerProfile` with akka-persistence-jdbc